### PR TITLE
Add gopath/src check

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Go language plugin for ThoughtWorks [Gauge](http://getgauge.io).
 
 ## Getting started in 3 steps
 * Install [Gauge](http://getgauge.io) by following instructions [here](http://getgauge.io/get-started/) and gauge go plugin as `gauge --install go`
-* Initialize a golang gauge project in GOPATH as: `gauge --init go`
+* Initialize a golang gauge project in subfolder within `GOPATH/src` directory as: 
+```sh
+cd $GOPATH/src
+mkdir gaugeproject
+cd gaugeproject
+gauge --init go
+```
 * Run specs: `gauge specs`
 
 ## Installation
@@ -44,7 +50,7 @@ To initialize a project with gauge-go, in an empty directory run:
 ```sh
 $ gauge --init go
 ```
-**Note: Create your project in `GOPATH`.**
+**Note: Create your project in `GOPATH/src`.**
 
 **Run specs:**
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,12 @@ func setPluginAndProjectRoots() {
 		fmt.Printf("Could not find %s env. Go Runner exiting...", common.GaugeProjectRootEnv)
 		os.Exit(1)
 	}
+
+	goSrcPath := filepath.Join(os.Getenv("GOPATH"), "src")
+	if !filepath.HasPrefix(projectRoot, goSrcPath) {
+		fmt.Printf("Project folder must be a subfolder in GOPATH/src folder\n")
+		os.Exit(1)
+	}
 }
 
 func createDirectory(dirPath string) {


### PR DESCRIPTION
The instruction "Create your project in GOPATH" maybe unclear to new golang users, they may not create sub-folder with GOPATH/**src** folder.

And if they run `gauge --init go` directly in GOPATH folder itself, or sub-folder like 'GOPATH/gauge-go-project', miss-leading compilation error message will show.

I think it's better to specify & check the project folder is sub-folder of GOPATH/**src**.