### PR TITLE
convert type when call step impl

### DIFF
--- a/testsuit/funcExecutor.go
+++ b/testsuit/funcExecutor.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,12 +27,26 @@ var CustomScreenShot *func() []byte
 
 // TODO: Use gauge-go result object rather than ProtoExecutionResult
 func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionResult) {
-	rargs := make([]reflect.Value, len(args))
-	for i, a := range args {
-		rargs[i] = reflect.ValueOf(a)
-	}
 	res = &m.ProtoExecutionResult{}
 	T = &testingT{}
+
+	rargs := make([]reflect.Value, len(args))
+	for i, a := range args {
+		if s, ok := a.(string); ok {
+			castedVal, err := convertType(fn.Type().In(i), s)
+			if err != nil {
+				res.ScreenShot = getScreenshot()
+				res.Failed = true
+				res.ExecutionTime = 0
+				res.StackTrace = " " // make sure that the error message is displayed on the report html
+				res.ErrorMessage = err.Error()
+				return res
+			}
+			rargs[i] = castedVal
+			continue
+		}
+		rargs[i] = reflect.ValueOf(a)
+	}
 	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
@@ -76,4 +91,38 @@ func getScreenshot() []byte {
 		return bytes
 	}
 	return nil
+}
+
+func convertType(t reflect.Type, strVal string) (reflect.Value, error) {
+	if t.Kind() == reflect.String {
+		return reflect.ValueOf(strVal), nil
+	}
+	tBitSize := int(t.Size()) * 8
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(strVal, 10, tBitSize)
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot convert %#v to a %s value: %s", strVal, t.String(), err.Error())
+		}
+		intVal := reflect.New(t)
+		intVal.Elem().SetInt(n)
+		return intVal.Elem(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(strVal, 10, tBitSize)
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot convert %#v to a %s value: %s", strVal, t.String(), err.Error())
+		}
+		uintVal := reflect.New(t)
+		uintVal.Elem().SetUint(n)
+		return uintVal.Elem(), nil
+	case reflect.Float32, reflect.Float64:
+		n, err := strconv.ParseFloat(strVal, tBitSize)
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot convert %#v to a %s value: %s", strVal, t.String(), err.Error())
+		}
+		floatVal := reflect.New(t)
+		floatVal.Elem().SetFloat(n)
+		return floatVal.Elem(), nil
+	}
+	return reflect.Value{}, fmt.Errorf("cannot convert a string to a %s value")
 }


### PR DESCRIPTION
```markdown
* "123" is an odd number
```

```go
gauge.Step("<n> is an odd number", func(n string) {
    i , err := strconv.Atoi(n)     // you should parse the data before using it
    if err != nil {
        T.Fail(err)
    }
    if i % 2 == 0 {
        T.Errorf("%d is not an odd number", i)
    }
})
```
-----

```go
gauge.Step("<n> is an odd number", func(n int) {    // converted by gauge
    if n % 2 == 0 {
        T.Errorf("%d is not an odd number", n)
    }
})
```