### PR TITLE
Go Modules support

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,8 +69,8 @@ func setPluginAndProjectRoots() {
 		os.Exit(1)
 	}
 
-	if !checkIfInSrcPath(projectRoot) {
-		fmt.Printf("Project folder must be a subfolder in GOPATH/src folder\n")
+	if !checkIfInSrcPath(projectRoot) && !checkGoModulesAvailable() {
+		fmt.Printf("Project folder must be a subfolder in GOPATH/src folder, or Go Modules must be available (go1.11+)\n")
 		os.Exit(1)
 	}
 }
@@ -108,6 +108,16 @@ func getGoSrcPaths() []string {
 func checkIfInSrcPath(dirPath string) bool {
 	for _, p := range getGoSrcPaths() {
 		if filepath.HasPrefix(dirPath, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkGoModulesAvailable() bool {
+	minReleaseTag := "go1.11"
+	for _, tag := range build.Default.ReleaseTags {
+		if minReleaseTag == tag {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ func main() {
 }
 
 func startGo() {
+	if requiresGoModuleFile(projectRoot) {
+		fmt.Printf("Failed to start runner; go.mod is required when working outside the GOPATH.\nCreate it using `go mod init <module-name>`\n")
+		os.Exit(1)
+	}
 	err := gauge.LoadGaugeImpls(projectRoot)
 	if err != nil {
 		fmt.Printf("Failed to build project: %s\nKilling go runner. \n", err.Error())
@@ -140,7 +144,6 @@ func checkGoModulesAvailable() bool {
 }
 
 func requiresGoModuleFile(dirPath string) bool {
-
 	// Module file is never required in GOPATH
 	if checkIfInSrcPath(dirPath) {
 		return false


### PR DESCRIPTION
Allow test projects to exist outside of $GOPATH by using Go Modules.

Fixes #18 