### PR TITLE
Here we have to return milliseconds

### DIFF
--- a/testsuit/funcExecutor.go
+++ b/testsuit/funcExecutor.go
@@ -37,7 +37,7 @@ func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionRe
 		if r := recover(); r != nil {
 			res.ScreenShot = getScreenshot()
 			res.Failed = true
-			res.ExecutionTime = time.Since(start).Nanoseconds()
+			res.ExecutionTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
 			res.StackTrace = strings.SplitN(string(debug.Stack()), "\n", 9)[8]
 			res.ErrorMessage = fmt.Sprintf("%s", r)
 		}
@@ -51,7 +51,7 @@ func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionRe
 		res.StackTrace = T.getStacktraces()
 		res.ErrorMessage = T.getErrors()
 	}
-	res.ExecutionTime = time.Since(start).Nanoseconds()
+	res.ExecutionTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
 	return res
 }
 


### PR DESCRIPTION
If we check [proper gauge code](https://github.com/getgauge/gauge/blob/f7ee574a0bf95ebc295f7b4faa4224649e44528c/execution/result/suiteResult.go#L81) 
Or [gauge-js plugin](https://github.com/getgauge/gauge-js/blob/79c41ece810c53e57f3ebb3751a8e7ad399baef5/src/test.js#L19)
It will become clear that here we have to return milliseconds