### PR TITLE
set go test timout to infinite, and use the gauge timeout to prevent indefinite running specs

### DIFF
--- a/gauge/builder.go
+++ b/gauge/builder.go
@@ -49,7 +49,7 @@ func LoadGaugeImpls(projectRoot string) error {
 	genGaugeTestFileContents(f, b.String(), vendorPackages)
 	f.Close()
 	// Scan gauge methods
-	if err := util.RunCommand(os.Stdout, os.Stdout, constants.CommandGo, "test", "-v", gaugeGoMainFile); err != nil {
+	if err := util.RunCommand(os.Stdout, os.Stdout, constants.CommandGo, "test", "-timeout", "0", "-v", gaugeGoMainFile); err != nil {
 		return fmt.Errorf("Failed to compile project: %s\nPlease ensure the project is in GOPATH.\n", err.Error())
 	}
 	return nil


### PR DESCRIPTION
Issue no 24
https://github.com/getgauge-contrib/gauge-go/issues/24

set the default timeout to 0 for running go tests to prevent the tests timing out.
In order to prevent infite specs running, the timout set within gauge configuration will prevent this.

This seemed the most sensible change without adding additional configuraton setup?

