### PR TITLE
Add support for Continue on failure

### DIFF
--- a/testsuit/funcExecutor.go
+++ b/testsuit/funcExecutor.go
@@ -40,6 +40,7 @@ func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionRe
 			res.ExecutionTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
 			res.StackTrace = strings.SplitN(string(debug.Stack()), "\n", 9)[8]
 			res.ErrorMessage = fmt.Sprintf("%s", r)
+			res.RecoverableError = T.getContinueOnFailure()
 		}
 		T = &testingT{}
 	}()
@@ -50,6 +51,7 @@ func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionRe
 		res.Failed = true
 		res.StackTrace = T.getStacktraces()
 		res.ErrorMessage = T.getErrors()
+		res.RecoverableError = T.getContinueOnFailure()
 	}
 	res.ExecutionTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
 	return res

--- a/testsuit/step_test.go
+++ b/testsuit/step_test.go
@@ -42,6 +42,7 @@ func TestShouldReturnPassedMethodExecutionResult(t *testing.T) {
 	assert.NotZero(t, res.GetExecutionTime())
 	assert.Zero(t, res.GetErrorMessage())
 	assert.Zero(t, res.GetStackTrace())
+	assert.False(t, res.GetRecoverableError())
 }
 
 func TestShouldReturnFailedMethodExecutionResult(t *testing.T) {
@@ -62,4 +63,27 @@ func TestShouldReturnFailedMethodExecutionResult(t *testing.T) {
 	assert.NotZero(t, res.GetExecutionTime())
 	assert.Equal(t, "runtime error: index out of range", res.GetErrorMessage())
 	assert.NotZero(t, res.GetStackTrace())
+	assert.False(t, res.GetRecoverableError())
+}
+
+func TestShouldReturnFailedButContinuableMethodExecutionResult(t *testing.T) {
+	var called bool
+	step := Step{
+		Description: "Test description",
+		Impl: func(args ...interface{}) {
+			T.ContinueOnFailure()
+			called = true
+			var a []string
+			fmt.Println(a[7])
+		},
+	}
+
+	res := step.Execute("foo")
+
+	assert.True(t, called)
+	assert.True(t, res.GetFailed())
+	assert.NotZero(t, res.GetExecutionTime())
+	assert.Equal(t, "runtime error: index out of range", res.GetErrorMessage())
+	assert.NotZero(t, res.GetStackTrace())
+	assert.True(t, res.GetRecoverableError())
 }

--- a/testsuit/step_test.go
+++ b/testsuit/step_test.go
@@ -83,7 +83,7 @@ func TestShouldReturnFailedButContinuableMethodExecutionResult(t *testing.T) {
 	assert.True(t, called)
 	assert.True(t, res.GetFailed())
 	assert.NotZero(t, res.GetExecutionTime())
-	assert.Equal(t, "runtime error: index out of range", res.GetErrorMessage())
+	assert.Equal(t, "runtime error: index out of range [7] with length 0", res.GetErrorMessage())
 	assert.NotZero(t, res.GetStackTrace())
 	assert.True(t, res.GetRecoverableError())
 }

--- a/testsuit/testing.go
+++ b/testsuit/testing.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"runtime/debug"
 	"strings"
+	"testing"
 )
 
 // T is a wrapper around *testing.T
 var T *testingT
 
 type testingT struct {
-	errors []testError
+	testing.T
+	errors            []testError
+	continueOnFailure bool
 }
 
 type testError struct {
@@ -34,9 +37,18 @@ func (t *testingT) getStacktraces() string {
 	return strings.Join(stacktraces, "\n\n")
 }
 
+func (t *testingT) getContinueOnFailure() bool {
+	return t.continueOnFailure
+}
+
 // Fail fails the step execution with the given error
 func (t *testingT) Fail(err error) {
 	panic(err)
+}
+
+// Any errors added through the Errorf method will now let the step continue to the next one.
+func (t *testingT) ContinueOnFailure() {
+	t.continueOnFailure = true
 }
 
 // Errorf records the error given, but step execution continues. However, the step is marked as failure.


### PR DESCRIPTION
Fixes #4

This PR implements the following Gauge feature for gauge-go
https://docs.gauge.org/writing-specifications.html?os=linux&language=java&ide=vscode#continue-on-failure 

Users can opt into this feature by calling `T.ContinueOnFailure()` where `T` is the `T *testingT` object already exposed in the `testsuit` package. Users are already using that exposed object to do assertions on steps. 

The unit test of this Pull Request has an example of how to use this feature. 

