### PR TITLE
Add remote debugging option with dlv

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ $ gauge init go
 $ gauge run specs/
 ```
 
+**Run specs with remote debugging enabled:**
+
+```sh
+$ GAUGE_DEBUG_OPTS=40000 gauge run specs/
+```
 ## Methods
 
 ### Step implementation

--- a/go.json
+++ b/go.json
@@ -1,7 +1,12 @@
 {
     "id": "go",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "description": "Go support for gauge",
+    "preInstall": {
+        "windows": ["go", "get", "github.com/go-delve/delve/cmd/dlv"],
+        "linux": ["go", "get", "github.com/go-delve/delve/cmd/dlv"],
+        "darwin": ["go", "get", "github.com/go-delve/delve/cmd/dlv"]
+    },
     "run": {
         "windows": ["bin/gauge-go", "--start"],
         "linux": ["bin/gauge-go", "--start"],


### PR DESCRIPTION
Fix https://github.com/getgauge-contrib/gauge-go/issues/20

After running the spec in debugging mode you will need to connect to the running process with your IDE. Here one example of how to do it on Intellij

https://kupczynski.info/2020/05/17/remote-debug-go-code.html
