### PR TITLE
Show caller instead of entire stacktrace

### DIFF
--- a/testsuit/funcExecutor.go
+++ b/testsuit/funcExecutor.go
@@ -8,8 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime/debug"
-	"strings"
+	"runtime"
 	"time"
 
 	"github.com/getgauge-contrib/gauge-go/constants"
@@ -38,7 +37,7 @@ func executeFunc(fn reflect.Value, args ...interface{}) (res *m.ProtoExecutionRe
 			res.ScreenShot = getScreenshot()
 			res.Failed = true
 			res.ExecutionTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
-			res.StackTrace = strings.SplitN(string(debug.Stack()), "\n", 9)[8]
+			res.StackTrace = caller(4)
 			res.ErrorMessage = fmt.Sprintf("%s", r)
 			res.RecoverableError = T.getContinueOnFailure()
 		}
@@ -78,4 +77,9 @@ func getScreenshot() []byte {
 		return bytes
 	}
 	return nil
+}
+
+func caller(skip int) string {
+	_, file, line, _ := runtime.Caller(skip)
+	return fmt.Sprintf("\t%s:%d", file, line)
 }

--- a/testsuit/testing.go
+++ b/testsuit/testing.go
@@ -2,7 +2,6 @@ package testsuit
 
 import (
 	"fmt"
-	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -53,5 +52,5 @@ func (t *testingT) ContinueOnFailure() {
 
 // Errorf records the error given, but step execution continues. However, the step is marked as failure.
 func (t *testingT) Errorf(format string, args ...interface{}) {
-	t.errors = append(t.errors, testError{errMsg: fmt.Sprintf(format, args...), stacktrace: string(debug.Stack())})
+	t.errors = append(t.errors, testError{errMsg: fmt.Sprintf(format, args...), stacktrace: caller(2)})
 }


### PR DESCRIPTION
Currently when a test fails the entire stacktrace is dumped;
```
# Specification Heading
  ## Vowel counts in single word         P F
        Failed Step: The word "gauge" has "2" vowels.
        Specification: specs\example.spec:17
        Error Message: got: 3, want: 2
        Stacktrace: 
                C:/Go/workspace/pkg/mod/github.com/getgauge-contrib/gauge-go@v0.2.0/testsuit/testing.go:46
        gaugeplay/stepimpl.glob..func3(0xc00000dc50, 0x5, 0x7c7db0, 0x1)
                C:/gauge-trace/stepimpl/stepimpl.go:42 +0x1cd
        reflect.Value.call(0x530380, 0x5b3638, 0x13, 0x59b6b6, 0x4, 0xc0003153e0, 0x2, 0x2, 0xc00010f9f8, 0x21f13f, ...)
                C:/Go/src/reflect/value.go:476 +0x907
        reflect.Value.Call(0x530380, 0x5b3638, 0x13, 0xc0003153e0, 0x2, 0x2, 0xc000047000, 0x0, 0x2)
                C:/Go/src/reflect/value.go:337 +0xc5
        github.com/getgauge-contrib/gauge-go/testsuit.executeFunc(0x530380, 0x5b3638, 0x13, 0xc000047000, 0x2, 0x2, 0xc000318a10)
                C:/Go/workspace/pkg/mod/github.com/getgauge-contrib/gauge-go@v0.2.0/testsuit/funcExecutor.go:47 +0x249
        github.com/getgauge-contrib/gauge-go/testsuit.(*Step).Execute(0xc000046fe0, 0xc000047000, 0x2, 0x2, 0x0)
                C:/Go/workspace/pkg/mod/github.com/getgauge-contrib/gauge-go@v0.2.0/testsuit/step.go:17 +0xc5
        github.com/getgauge-contrib/gauge-go/messageprocessors.(*ExecuteStepProcessor).Process(0x83b268, 0xc00019fb30, 0xc000050360, 0xc000216038)
                C:/Go/workspace/pkg/mod/github.com/getgauge-contrib/gauge-go@v0.2.0/messageprocessors/ExecuteStepProcessor.go:20 +0x97
        github.com/getgauge-contrib/gauge-go/gauge.Run()
                C:/Go/workspace/pkg/mod/github.com/getgauge-contrib/gauge-go@v0.2.0/gauge/runner.go:219 +0x2b4
        command-line-arguments.init.0()
                C:/Users/FERDY~1.PRU/AppData/Local/Temp/gauge_temp1627894943063976400/gauge_test.go:8 +0x29
```

While most of the times you are only concerned with where exactly the test failed. 
I therefor propose this change to only show the caller of `testingT.Fail`/`testingT.Error`;
```
# Specification Heading
  ## Vowel counts in single word         P F
        Failed Step: The word "gauge" has "2" vowels.
        Specification: specs\example.spec:17
        Error Message: got: 3, want: 2
        Stacktrace: 
                C:/gauge-trace/stepimpl/stepimpl.go:42
```

The content of `C:\gauge-trace\stepimpl\stepimpl.go:42` is
```
T.Fail(fmt.Errorf("got: %d, want: %d", actualCount, expectedCount))
```

I am aware this is not ideal either, but I believe it to be an improvement when confronted with broken tests.