### PR TITLE
Expose execution context details in hook

### DIFF
--- a/gauge/runner.go
+++ b/gauge/runner.go
@@ -49,7 +49,7 @@ func init() {
 
 // BeforeSuite hook is executed before suite execution begins
 // This can be used for any setup before execution begins.
-func BeforeSuite(fn func(), tags []string, op t.Operator) bool {
+func BeforeSuite(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.BEFORESUITE,
 		Impl:     fn,
@@ -63,7 +63,7 @@ func BeforeSuite(fn func(), tags []string, op t.Operator) bool {
 
 // AfterSuite hook is executed after hook execution is completed.
 // This can be used for any cleanup after entire execution.
-func AfterSuite(fn func(), tags []string, op t.Operator) bool {
+func AfterSuite(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.AFTERSUITE,
 		Impl:     fn,
@@ -78,7 +78,7 @@ func AfterSuite(fn func(), tags []string, op t.Operator) bool {
 // BeforeSpec hook is executed before every spec execution begins
 // This can be used for any spec setup before execution begins. It can be executed for only a specific set of specs using Tags.
 // This hook will be executed only for specs which satisfy the tags and tag operator(AND or OR) mentioned.
-func BeforeSpec(fn func(), tags []string, op t.Operator) bool {
+func BeforeSpec(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.BEFORESPEC,
 		Impl:     fn,
@@ -93,7 +93,7 @@ func BeforeSpec(fn func(), tags []string, op t.Operator) bool {
 // AfterSpec hook is executed after every spec execution.
 // This can be used for any spec cleanup after execution. It can be executed for only a specific set of specs using Tags.
 // This hook will be executed only for specs which satisfy the tags and tag operator(AND or OR) mentioned.
-func AfterSpec(fn func(), tags []string, op t.Operator) bool {
+func AfterSpec(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.AFTERSPEC,
 		Impl:     fn,
@@ -108,7 +108,7 @@ func AfterSpec(fn func(), tags []string, op t.Operator) bool {
 // BeforeScenario hook is executed before every scenario execution begins.
 // This can be used for any scenario setup before execution begins. It can be executed for only a specific set of specs using Tags.
 // This hook will be executed only for scenario which satisfy the tags and tag operator(AND or OR) mentioned.
-func BeforeScenario(fn func(), tags []string, op t.Operator) bool {
+func BeforeScenario(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.BEFORESCENARIO,
 		Impl:     fn,
@@ -123,7 +123,7 @@ func BeforeScenario(fn func(), tags []string, op t.Operator) bool {
 // AfterScenario hook is executed after every scenario execution.
 // This can be used for any spec cleanup after execution. It can be executed for only a specific set of specs using Tags.
 // This hook will be executed only for scenarios which satisfy the tags and tag operator(AND or OR) mentioned.
-func AfterScenario(fn func(), tags []string, op t.Operator) bool {
+func AfterScenario(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.AFTERSCENARIO,
 		Impl:     fn,
@@ -137,7 +137,7 @@ func AfterScenario(fn func(), tags []string, op t.Operator) bool {
 
 // BeforeStep hook is executed before every step execution begins.
 // This can be used for any step setup before execution begins.
-func BeforeStep(fn func(), tags []string, op t.Operator) bool {
+func BeforeStep(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.BEFORESTEP,
 		Impl:     fn,
@@ -151,7 +151,7 @@ func BeforeStep(fn func(), tags []string, op t.Operator) bool {
 
 // AfterStep hook is executed before after every step execution.
 // This can be used for any step cleanup after execution.
-func AfterStep(fn func(), tags []string, op t.Operator) bool {
+func AfterStep(fn func(exInfo *m.ExecutionInfo), tags []string, op t.Operator) bool {
 	hook := t.Hook{
 		Type:     t.AFTERSTEP,
 		Impl:     fn,

--- a/messageprocessors/ExecutionEndingProcessor.go
+++ b/messageprocessors/ExecutionEndingProcessor.go
@@ -10,6 +10,7 @@ type ExecutionEndingProcessor struct{}
 func (r *ExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
 	hooks := context.GetHooks(t.AFTERSUITE, tags)
+	exInfo := msg.GetExecutionEndingRequest().GetCurrentExecutionInfo()
 
-	return executeHooks(hooks, msg)
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/ExecutionEndingProcessor_test.go
+++ b/messageprocessors/ExecutionEndingProcessor_test.go
@@ -34,7 +34,7 @@ func TestExecutesHooksForTheTagsForScenarioEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -42,7 +42,7 @@ func TestExecutesHooksForTheTagsForScenarioEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -81,7 +81,7 @@ func TestReportErrorIfHookFailsForScenarioEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -89,7 +89,7 @@ func TestReportErrorIfHookFailsForScenarioEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/ExecutionStartingRequestProcessor.go
+++ b/messageprocessors/ExecutionStartingRequestProcessor.go
@@ -11,6 +11,7 @@ func (r *ExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.G
 
 	tags := msg.GetExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
 	hooks := context.GetHooks(t.BEFORESUITE, tags)
+	exInfo := msg.GetExecutionStartingRequest().GetCurrentExecutionInfo()
 
-	return executeHooks(hooks, msg)
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/ExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/ExecutionStartingRequestProcessor_test.go
@@ -34,7 +34,7 @@ func TestExecutesHooksForTheTags(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -42,7 +42,7 @@ func TestExecutesHooksForTheTags(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -81,7 +81,7 @@ func TestReportErrorIfHookFails(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -89,7 +89,7 @@ func TestReportErrorIfHookFails(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESUITE,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/Helper.go
+++ b/messageprocessors/Helper.go
@@ -5,11 +5,11 @@ import (
 	t "github.com/getgauge-contrib/gauge-go/testsuit"
 )
 
-func executeHooks(hooks []t.Hook, msg *m.Message) *m.Message {
+func executeHooks(hooks []t.Hook, msg *m.Message, exInfo *m.ExecutionInfo) *m.Message {
 	var res *m.ProtoExecutionResult
 	var totalExecutionTime int64
 	for _, hook := range hooks {
-		res = hook.Execute()
+		res = hook.Execute(exInfo)
 		totalExecutionTime += res.GetExecutionTime()
 		if res.GetFailed() {
 			return &m.Message{

--- a/messageprocessors/ScenarioExecutionEndingProcessor.go
+++ b/messageprocessors/ScenarioExecutionEndingProcessor.go
@@ -10,5 +10,7 @@ type ScenarioExecutionEndingProcessor struct{}
 func (r *ScenarioExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetScenarioExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
 	hooks := context.GetHooks(t.AFTERSCENARIO, tags)
-	return executeHooks(hooks, msg)
+	exInfo := msg.GetScenarioExecutionEndingRequest().GetCurrentExecutionInfo()
+
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/ScenarioExecutionEndingProcessor_test.go
+++ b/messageprocessors/ScenarioExecutionEndingProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForScenarioExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForScenarioExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -82,7 +82,7 @@ func TestReportErrorIfHookFailsForScenarioExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -90,7 +90,7 @@ func TestReportErrorIfHookFailsForScenarioExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/ScenarioExecutionStartingRequestProcessor.go
+++ b/messageprocessors/ScenarioExecutionStartingRequestProcessor.go
@@ -10,6 +10,7 @@ type ScenarioExecutionStartingRequestProcessor struct{}
 func (r *ScenarioExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetScenarioExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
 	hooks := context.GetHooks(t.BEFORESCENARIO, tags)
+	exInfo := msg.GetScenarioExecutionStartingRequest().GetCurrentExecutionInfo()
 
-	return executeHooks(hooks, msg)
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/ScenarioExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/ScenarioExecutionStartingRequestProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForScenarioExecutionStartingRequest(tst *testing
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForScenarioExecutionStartingRequest(tst *testing
 			},
 			t.Hook{
 				Type: t.BEFORESCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -81,7 +81,7 @@ func TestReportErrorIfHookFailsForScenarioExecutionStartingRequest(tst *testing.
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -89,7 +89,7 @@ func TestReportErrorIfHookFailsForScenarioExecutionStartingRequest(tst *testing.
 			},
 			t.Hook{
 				Type: t.BEFORESCENARIO,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/SpecExecutionEndingProcessor.go
+++ b/messageprocessors/SpecExecutionEndingProcessor.go
@@ -10,6 +10,7 @@ type SpecExecutionEndingProcessor struct{}
 func (r *SpecExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetSpecExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
 	hooks := context.GetHooks(t.AFTERSPEC, tags)
+	exInfo := msg.GetSpecExecutionEndingRequest().GetCurrentExecutionInfo()
 
-	return executeHooks(hooks, msg)
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/SpecExecutionEndingProcessor_test.go
+++ b/messageprocessors/SpecExecutionEndingProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForSpecExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForSpecExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -82,7 +82,7 @@ func TestReportErrorIfHookFailsForSpecExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -90,7 +90,7 @@ func TestReportErrorIfHookFailsForSpecExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/SpecExecutionStartingRequestProcessor.go
+++ b/messageprocessors/SpecExecutionStartingRequestProcessor.go
@@ -10,6 +10,7 @@ type SpecExecutionStartingRequestProcessor struct{}
 func (r *SpecExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetSpecExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
 	hooks := context.GetHooks(t.BEFORESPEC, tags)
+	exInfo := msg.GetSpecExecutionStartingRequest().GetCurrentExecutionInfo()
 
-	return executeHooks(hooks, msg)
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/SpecExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/SpecExecutionStartingRequestProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForSpecExecutionStarting(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForSpecExecutionStarting(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -82,7 +82,7 @@ func TestReportErrorIfHookFailsForSpecExecutionStarting(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -90,7 +90,7 @@ func TestReportErrorIfHookFailsForSpecExecutionStarting(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESPEC,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/messageprocessors/StepExecutionEndingProcessor.go
+++ b/messageprocessors/StepExecutionEndingProcessor.go
@@ -10,8 +10,9 @@ type StepExecutionEndingProcessor struct{}
 func (r *StepExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetStepExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
 	hooks := context.GetHooks(t.AFTERSTEP, tags)
+	exInfo := msg.GetStepExecutionEndingRequest().GetCurrentExecutionInfo()
 
-	res := executeHooks(hooks, msg)
+	res := executeHooks(hooks, msg, exInfo)
 	res.GetExecutionStatusResponse().GetExecutionResult().Message = context.CustomMessageRegistry
 	context.ClearCustomMessages()
 

--- a/messageprocessors/StepExecutionEndingProcessor_test.go
+++ b/messageprocessors/StepExecutionEndingProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForStepExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForStepExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -82,7 +82,7 @@ func TestReportErrorIfHookFailsForStepExecutionEnding(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -90,7 +90,7 @@ func TestReportErrorIfHookFailsForStepExecutionEnding(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.AFTERSTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))
@@ -134,7 +134,7 @@ func TestShouldReturnCustomMessagesInResult(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.AFTERSTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called = true
 				},
 				Operator: t.AND,

--- a/messageprocessors/StepExecutionStartingRequestProcessor.go
+++ b/messageprocessors/StepExecutionStartingRequestProcessor.go
@@ -10,6 +10,8 @@ type StepExecutionStartingRequestProcessor struct{}
 func (r *StepExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 	tags := msg.GetStepExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
 	hooks := context.GetHooks(t.BEFORESTEP, tags)
+	exInfo := msg.GetStepExecutionStartingRequest().GetCurrentExecutionInfo()
 	context.ClearCustomMessages()
-	return executeHooks(hooks, msg)
+
+	return executeHooks(hooks, msg, exInfo)
 }

--- a/messageprocessors/StepExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/StepExecutionStartingRequestProcessor_test.go
@@ -35,7 +35,7 @@ func TestExecutesHooksForTheTagsForStepExecutionStarting(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -43,7 +43,7 @@ func TestExecutesHooksForTheTagsForStepExecutionStarting(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
@@ -82,7 +82,7 @@ func TestReportErrorIfHookFailsForStepExecutionStarting(tst *testing.T) {
 		Hooks: []t.Hook{
 			t.Hook{
 				Type: t.BEFORESTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
 				Tags:     []string{"foo", "bar"},
@@ -90,7 +90,7 @@ func TestReportErrorIfHookFailsForStepExecutionStarting(tst *testing.T) {
 			},
 			t.Hook{
 				Type: t.BEFORESTEP,
-				Impl: func() {
+				Impl: func(*m.ExecutionInfo) {
 					called2 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))

--- a/testsuit/gaugecontext_test.go
+++ b/testsuit/gaugecontext_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	m "github.com/getgauge-contrib/gauge-go/gauge_messages"
 )
 
 func TestShouldGetStepsWithDescription(t *testing.T) {
@@ -43,7 +44,7 @@ func TestShouldGetHooksOfGivenType(t *testing.T) {
 		Hooks: []Hook{
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{},
 				Operator: AND,
 			},
@@ -60,13 +61,13 @@ func TestShouldGetHooksWithAnyOfTheseTags(t *testing.T) {
 		Hooks: []Hook{
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"foo", "bar"},
 				Operator: OR,
 			},
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"notfoo", "bar"},
 				Operator: OR,
 			},
@@ -84,13 +85,13 @@ func TestShouldNotGetHooksIfTagsDontMatch(t *testing.T) {
 		Hooks: []Hook{
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"foo", "bar"},
 				Operator: OR,
 			},
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"notfoo", "bar"},
 				Operator: OR,
 			},
@@ -106,13 +107,13 @@ func TestShouldGetHooksWithBothTags(t *testing.T) {
 		Hooks: []Hook{
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"foo", "bar"},
 				Operator: AND,
 			},
 			Hook{
 				Type:     BEFORESUITE,
-				Impl:     func() {},
+				Impl:     func(*m.ExecutionInfo) {},
 				Tags:     []string{"notfoo", "bar"},
 				Operator: AND,
 			},

--- a/testsuit/hook.go
+++ b/testsuit/hook.go
@@ -28,12 +28,12 @@ const (
 
 type Hook struct {
 	Type     HookType
-	Impl     func()
+	Impl     func(*m.ExecutionInfo)
 	Tags     []string
 	Operator Operator
 }
 
-func (hook *Hook) Execute() *m.ProtoExecutionResult {
+func (hook *Hook) Execute(exInfo *m.ExecutionInfo) *m.ProtoExecutionResult {
 	fn := reflect.ValueOf(hook.Impl)
-	return executeFunc(fn)
+	return executeFunc(fn, exInfo)
 }

--- a/testsuit/step_test.go
+++ b/testsuit/step_test.go
@@ -76,6 +76,7 @@ func TestShouldReturnFailedButContinuableMethodExecutionResult(t *testing.T) {
 		Description: "Test description",
 		Impl: func(args ...interface{}) {
 			T.ContinueOnFailure()
+			doWork()
 			called = true
 			var a []string
 			fmt.Println(a[7])


### PR DESCRIPTION
Relates to #5 

In commit: ce4571d907bf32d64aa9f4e5e095449d3b3305f1 you can see a possible solution for this problem.

The changed `func()` also could be `func(interface{})` instead specific type `*m.ExecutionInfo` like in case of `Step` struct.