### PR TITLE
Change execution hook filtering based on tags 

### DIFF
--- a/messageprocessors/ExecutionEndingProcessor.go
+++ b/messageprocessors/ExecutionEndingProcessor.go
@@ -8,7 +8,7 @@ import (
 type ExecutionEndingProcessor struct{}
 
 func (r *ExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
-	tags := msg.GetExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
+	tags := []string{}
 	hooks := context.GetHooks(t.AFTERSUITE, tags)
 	exInfo := msg.GetExecutionEndingRequest().GetCurrentExecutionInfo()
 

--- a/messageprocessors/ExecutionEndingProcessor_test.go
+++ b/messageprocessors/ExecutionEndingProcessor_test.go
@@ -30,6 +30,7 @@ func TestShouldReturnExecutionStatusResponseWithSameId(tst *testing.T) {
 func TestExecutesHooksForTheTagsForScenarioEnding(tst *testing.T) {
 	called1 := false
 	called2 := false
+	called3 := false
 	context := &t.GaugeContext{
 		Hooks: []t.Hook{
 			t.Hook{
@@ -37,13 +38,19 @@ func TestExecutesHooksForTheTagsForScenarioEnding(tst *testing.T) {
 				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
+			},
+			t.Hook{
+				Type: t.AFTERSUITE,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
 				Tags:     []string{"foo", "bar"},
 				Operator: t.AND,
 			},
 			t.Hook{
 				Type: t.AFTERSUITE,
 				Impl: func(*m.ExecutionInfo) {
-					called2 = true
+					called3 = true
 				},
 				Tags:     []string{"notfoo", "bar"},
 				Operator: t.OR,
@@ -71,6 +78,7 @@ func TestExecutesHooksForTheTagsForScenarioEnding(tst *testing.T) {
 	assert.Equal(tst, result.MessageId, msgId)
 	assert.True(tst, called1)
 	assert.True(tst, called2)
+	assert.True(tst, called3)
 
 }
 

--- a/messageprocessors/ExecutionStartingRequestProcessor.go
+++ b/messageprocessors/ExecutionStartingRequestProcessor.go
@@ -9,7 +9,7 @@ type ExecutionStartingRequestProcessor struct{}
 
 func (r *ExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
 
-	tags := msg.GetExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
+	tags := []string{}
 	hooks := context.GetHooks(t.BEFORESUITE, tags)
 	exInfo := msg.GetExecutionStartingRequest().GetCurrentExecutionInfo()
 

--- a/messageprocessors/ExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/ExecutionStartingRequestProcessor_test.go
@@ -77,6 +77,7 @@ func TestExecutesHooksForTheTags(tst *testing.T) {
 func TestReportErrorIfHookFails(tst *testing.T) {
 	called1 := false
 	called2 := false
+	called3 := false
 	context := &t.GaugeContext{
 		Hooks: []t.Hook{
 			t.Hook{
@@ -84,13 +85,19 @@ func TestReportErrorIfHookFails(tst *testing.T) {
 				Impl: func(*m.ExecutionInfo) {
 					called1 = true
 				},
+			},
+			t.Hook{
+				Type: t.BEFORESUITE,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
 				Tags:     []string{"foo", "bar"},
 				Operator: t.AND,
 			},
 			t.Hook{
 				Type: t.BEFORESUITE,
 				Impl: func(*m.ExecutionInfo) {
-					called2 = true
+					called3 = true
 					if 1 == 1 {
 						panic(errors.New("Execution failed"))
 					}
@@ -119,6 +126,7 @@ func TestReportErrorIfHookFails(tst *testing.T) {
 
 	assert.True(tst, called1)
 	assert.True(tst, called2)
+	assert.True(tst, called3)
 	assert.Equal(tst, result.MessageType, m.Message_ExecutionStatusResponse)
 	assert.Equal(tst, result.MessageId, msgId)
 	assert.True(tst, result.ExecutionStatusResponse.ExecutionResult.Failed)

--- a/messageprocessors/Helper.go
+++ b/messageprocessors/Helper.go
@@ -41,3 +41,10 @@ func createResponseMessage(msgId int64, executionTime int64, err error) *m.Messa
 		},
 	}
 }
+
+func mergeSpecAndScenarioTags(exInfo *m.ExecutionInfo) (mergedTags []string){
+	specTags := exInfo.GetCurrentSpec().GetTags()
+	scenarioTags := exInfo.GetCurrentScenario().GetTags()
+	mergedTags = append(specTags, scenarioTags...)
+	return
+}

--- a/messageprocessors/ScenarioExecutionEndingProcessor.go
+++ b/messageprocessors/ScenarioExecutionEndingProcessor.go
@@ -8,7 +8,7 @@ import (
 type ScenarioExecutionEndingProcessor struct{}
 
 func (r *ScenarioExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
-	tags := msg.GetScenarioExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
+	tags := mergeSpecAndScenarioTags(msg.GetScenarioExecutionEndingRequest().GetCurrentExecutionInfo())
 	hooks := context.GetHooks(t.AFTERSCENARIO, tags)
 	exInfo := msg.GetScenarioExecutionEndingRequest().GetCurrentExecutionInfo()
 

--- a/messageprocessors/ScenarioExecutionEndingProcessor_test.go
+++ b/messageprocessors/ScenarioExecutionEndingProcessor_test.go
@@ -28,7 +28,7 @@ func TestShouldReturnExecutionStatusResponseWithSameIdForScenarioExecutionEnding
 	assert.Equal(tst, result.MessageId, msgId)
 }
 
-func TestExecutesHooksForTheTagsForScenarioExecutionEnding(tst *testing.T) {
+func TestExecutesHooksForScenarioTagsForScenarioExecutionEnding(tst *testing.T) {
 	called1 := false
 	called2 := false
 	context := &t.GaugeContext{
@@ -58,6 +58,53 @@ func TestExecutesHooksForTheTagsForScenarioExecutionEnding(tst *testing.T) {
 		ScenarioExecutionEndingRequest: &m.ScenarioExecutionEndingRequest{
 			CurrentExecutionInfo: &m.ExecutionInfo{
 				CurrentScenario: &m.ScenarioInfo{
+					Tags: []string{"foo", "bar"},
+				},
+			},
+		},
+	}
+
+	p := ScenarioExecutionEndingProcessor{}
+
+	result := p.Process(msg, context)
+
+	assert.Equal(tst, result.MessageType, m.Message_ExecutionStatusResponse)
+	assert.Equal(tst, result.MessageId, msgId)
+	assert.True(tst, called1)
+	assert.True(tst, called2)
+
+}
+
+func TestExecutesHooksForSpecTagsForScenarioExecutionEnding(tst *testing.T) {
+	called1 := false
+	called2 := false
+	context := &t.GaugeContext{
+		Hooks: []t.Hook{
+			t.Hook{
+				Type: t.AFTERSCENARIO,
+				Impl: func(*m.ExecutionInfo) {
+					called1 = true
+				},
+				Tags:     []string{"foo", "bar"},
+				Operator: t.AND,
+			},
+			t.Hook{
+				Type: t.AFTERSCENARIO,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
+				Tags:     []string{"notfoo", "bar"},
+				Operator: t.OR,
+			},
+		},
+	}
+	msgId := int64(12345)
+	msg := &m.Message{
+		MessageType: m.Message_ScenarioExecutionEnding,
+		MessageId:   msgId,
+		ScenarioExecutionEndingRequest: &m.ScenarioExecutionEndingRequest{
+			CurrentExecutionInfo: &m.ExecutionInfo{
+				CurrentSpec: &m.SpecInfo{
 					Tags: []string{"foo", "bar"},
 				},
 			},

--- a/messageprocessors/ScenarioExecutionStartingRequestProcessor.go
+++ b/messageprocessors/ScenarioExecutionStartingRequestProcessor.go
@@ -8,7 +8,7 @@ import (
 type ScenarioExecutionStartingRequestProcessor struct{}
 
 func (r *ScenarioExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
-	tags := msg.GetScenarioExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentScenario().GetTags()
+	tags := mergeSpecAndScenarioTags(msg.GetScenarioExecutionStartingRequest().GetCurrentExecutionInfo())
 	hooks := context.GetHooks(t.BEFORESCENARIO, tags)
 	exInfo := msg.GetScenarioExecutionStartingRequest().GetCurrentExecutionInfo()
 

--- a/messageprocessors/ScenarioExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/ScenarioExecutionStartingRequestProcessor_test.go
@@ -28,7 +28,7 @@ func TestShouldReturnExecutionStatusResponseWithSameIdForScenarioExecutionStarti
 	assert.Equal(tst, result.MessageId, msgId)
 }
 
-func TestExecutesHooksForTheTagsForScenarioExecutionStartingRequest(tst *testing.T) {
+func TestExecutesHooksForScenarioTagsForScenarioExecutionStartingRequest(tst *testing.T) {
 	called1 := false
 	called2 := false
 	context := &t.GaugeContext{
@@ -58,6 +58,52 @@ func TestExecutesHooksForTheTagsForScenarioExecutionStartingRequest(tst *testing
 		ScenarioExecutionStartingRequest: &m.ScenarioExecutionStartingRequest{
 			CurrentExecutionInfo: &m.ExecutionInfo{
 				CurrentScenario: &m.ScenarioInfo{
+					Tags: []string{"foo", "bar"},
+				},
+			},
+		},
+	}
+
+	p := ScenarioExecutionStartingRequestProcessor{}
+
+	result := p.Process(msg, context)
+
+	assert.Equal(tst, result.MessageType, m.Message_ExecutionStatusResponse)
+	assert.Equal(tst, result.MessageId, msgId)
+	assert.True(tst, called1)
+	assert.True(tst, called2)
+}
+
+func TestExecutesHooksForSpecTagsForScenarioExecutionStartingRequest(tst *testing.T) {
+	called1 := false
+	called2 := false
+	context := &t.GaugeContext{
+		Hooks: []t.Hook{
+			t.Hook{
+				Type: t.BEFORESCENARIO,
+				Impl: func(*m.ExecutionInfo) {
+					called1 = true
+				},
+				Tags:     []string{"foo", "bar"},
+				Operator: t.AND,
+			},
+			t.Hook{
+				Type: t.BEFORESCENARIO,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
+				Tags:     []string{"notfoo", "bar"},
+				Operator: t.OR,
+			},
+		},
+	}
+	msgId := int64(12345)
+	msg := &m.Message{
+		MessageType: m.Message_ScenarioExecutionStarting,
+		MessageId:   msgId,
+		ScenarioExecutionStartingRequest: &m.ScenarioExecutionStartingRequest{
+			CurrentExecutionInfo: &m.ExecutionInfo{
+				CurrentSpec: &m.SpecInfo{
 					Tags: []string{"foo", "bar"},
 				},
 			},

--- a/messageprocessors/StepExecutionEndingProcessor.go
+++ b/messageprocessors/StepExecutionEndingProcessor.go
@@ -8,7 +8,7 @@ import (
 type StepExecutionEndingProcessor struct{}
 
 func (r *StepExecutionEndingProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
-	tags := msg.GetStepExecutionEndingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
+	tags := mergeSpecAndScenarioTags(msg.GetStepExecutionEndingRequest().GetCurrentExecutionInfo())
 	hooks := context.GetHooks(t.AFTERSTEP, tags)
 	exInfo := msg.GetStepExecutionEndingRequest().GetCurrentExecutionInfo()
 

--- a/messageprocessors/StepExecutionEndingProcessor_test.go
+++ b/messageprocessors/StepExecutionEndingProcessor_test.go
@@ -28,7 +28,7 @@ func TestShouldReturnExecutionStatusResponseWithSameIdForStepExecutionEnding(tst
 	assert.Equal(tst, result.MessageId, msgId)
 }
 
-func TestExecutesHooksForTheTagsForStepExecutionEnding(tst *testing.T) {
+func TestExecutesHooksForSpecTagsForStepExecutionEnding(tst *testing.T) {
 	called1 := false
 	called2 := false
 	context := &t.GaugeContext{
@@ -58,6 +58,53 @@ func TestExecutesHooksForTheTagsForStepExecutionEnding(tst *testing.T) {
 		StepExecutionEndingRequest: &m.StepExecutionEndingRequest{
 			CurrentExecutionInfo: &m.ExecutionInfo{
 				CurrentSpec: &m.SpecInfo{
+					Tags: []string{"foo", "bar"},
+				},
+			},
+		},
+	}
+
+	p := StepExecutionEndingProcessor{}
+
+	result := p.Process(msg, context)
+
+	assert.Equal(tst, result.MessageType, m.Message_ExecutionStatusResponse)
+	assert.Equal(tst, result.MessageId, msgId)
+	assert.True(tst, called1)
+	assert.True(tst, called2)
+
+}
+
+func TestExecutesHooksForScenarioTagsForStepExecutionEnding(tst *testing.T) {
+	called1 := false
+	called2 := false
+	context := &t.GaugeContext{
+		Hooks: []t.Hook{
+			t.Hook{
+				Type: t.AFTERSTEP,
+				Impl: func(*m.ExecutionInfo) {
+					called1 = true
+				},
+				Tags:     []string{"foo", "bar"},
+				Operator: t.AND,
+			},
+			t.Hook{
+				Type: t.AFTERSTEP,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
+				Tags:     []string{"notfoo", "bar"},
+				Operator: t.OR,
+			},
+		},
+	}
+	msgId := int64(12345)
+	msg := &m.Message{
+		MessageType: m.Message_StepExecutionEnding,
+		MessageId:   msgId,
+		StepExecutionEndingRequest: &m.StepExecutionEndingRequest{
+			CurrentExecutionInfo: &m.ExecutionInfo{
+				CurrentScenario: &m.ScenarioInfo{
 					Tags: []string{"foo", "bar"},
 				},
 			},

--- a/messageprocessors/StepExecutionStartingRequestProcessor.go
+++ b/messageprocessors/StepExecutionStartingRequestProcessor.go
@@ -8,7 +8,7 @@ import (
 type StepExecutionStartingRequestProcessor struct{}
 
 func (r *StepExecutionStartingRequestProcessor) Process(msg *m.Message, context *t.GaugeContext) *m.Message {
-	tags := msg.GetStepExecutionStartingRequest().GetCurrentExecutionInfo().GetCurrentSpec().GetTags()
+	tags := mergeSpecAndScenarioTags(msg.GetStepExecutionStartingRequest().GetCurrentExecutionInfo())
 	hooks := context.GetHooks(t.BEFORESTEP, tags)
 	exInfo := msg.GetStepExecutionStartingRequest().GetCurrentExecutionInfo()
 	context.ClearCustomMessages()

--- a/messageprocessors/StepExecutionStartingRequestProcessor_test.go
+++ b/messageprocessors/StepExecutionStartingRequestProcessor_test.go
@@ -28,7 +28,7 @@ func TestShouldReturnExecutionStatusResponseWithSameIdForStepExecutionStarting(t
 	assert.Equal(tst, result.MessageId, msgId)
 }
 
-func TestExecutesHooksForTheTagsForStepExecutionStarting(tst *testing.T) {
+func TestExecutesHooksForSpecTagsForStepExecutionStarting(tst *testing.T) {
 	called1 := false
 	called2 := false
 	context := &t.GaugeContext{
@@ -58,6 +58,53 @@ func TestExecutesHooksForTheTagsForStepExecutionStarting(tst *testing.T) {
 		StepExecutionStartingRequest: &m.StepExecutionStartingRequest{
 			CurrentExecutionInfo: &m.ExecutionInfo{
 				CurrentSpec: &m.SpecInfo{
+					Tags: []string{"foo", "bar"},
+				},
+			},
+		},
+	}
+
+	p := StepExecutionStartingRequestProcessor{}
+
+	result := p.Process(msg, context)
+
+	assert.Equal(tst, result.MessageType, m.Message_ExecutionStatusResponse)
+	assert.Equal(tst, result.MessageId, msgId)
+	assert.True(tst, called1)
+	assert.True(tst, called2)
+
+}
+
+func TestExecutesHooksForScenarioTagsForStepExecutionStarting(tst *testing.T) {
+	called1 := false
+	called2 := false
+	context := &t.GaugeContext{
+		Hooks: []t.Hook{
+			t.Hook{
+				Type: t.BEFORESTEP,
+				Impl: func(*m.ExecutionInfo) {
+					called1 = true
+				},
+				Tags:     []string{"foo", "bar"},
+				Operator: t.AND,
+			},
+			t.Hook{
+				Type: t.BEFORESTEP,
+				Impl: func(*m.ExecutionInfo) {
+					called2 = true
+				},
+				Tags:     []string{"notfoo", "bar"},
+				Operator: t.OR,
+			},
+		},
+	}
+	msgId := int64(12345)
+	msg := &m.Message{
+		MessageType: m.Message_StepExecutionStarting,
+		MessageId:   msgId,
+		StepExecutionStartingRequest: &m.StepExecutionStartingRequest{
+			CurrentExecutionInfo: &m.ExecutionInfo{
+				CurrentScenario: &m.ScenarioInfo{
 					Tags: []string{"foo", "bar"},
 				},
 			},

--- a/testsuit/gaugecontext.go
+++ b/testsuit/gaugecontext.go
@@ -26,6 +26,12 @@ func (c *GaugeContext) GetStepByDesc(desc string) (*Step, error) {
 func (c *GaugeContext) GetHooks(hookType HookType, tags []string) []Hook {
 	filteredByType := filterByType(c.Hooks, hookType)
 	h := make([]Hook, 0)
+	//Suite Hooks are not filtered by tags
+	if BEFORESUITE == hookType ||
+	   AFTERSUITE  == hookType {
+		h = append(h, filteredByType...)
+		return h
+	}
 	//TODO complexity is O(n^3) optimize it
 	for _, hook := range filteredByType {
 		switch hook.Operator {


### PR DESCRIPTION
Fixes #35 

This change has 2 parts:

In both cases I modified and added tests to approve the new operations.

### 1.

Removes the tag filter operation from suite level.

**Tests**: I added 2 new test that shows this new operation:
* `TestBeforeSuiteShouldGetHooksIfTagsDontMatch`
* `TestAfterSuiteShouldGetHooksIfTagsDontMatch`

### 2.

Merges Spec and Scenario level tags when calling `scenario` or `step` execution hooks.

**Tests**: I added 4 new test that shows this new operation:

* `TestExecutesHooksForSpecTagsForScenarioExecutionEnding`
* `TestExecutesHooksForSpecTagsForScenarioExecutionStartingRequest`
* `TestExecutesHooksForSpecTagsForStepExecutionEnding`
* `TestExecutesHooksForSpecTagsForStepExecutionStarting`


